### PR TITLE
feat: convert from `poetry` to `uv` setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ A simple cookiecutter template for general python projects, including:
 
 ```sh
 cookiecutter gh:tunakasif/cookiecutter-pypackage
-cd <project_name>/
-make all
+cd <project-name>/
 make init
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A simple cookiecutter template for general python projects, including:
 ```sh
 cookiecutter gh:tunakasif/cookiecutter-pypackage
 cd <project_name>/
-make install
 make all
+make init
 ```
 
 ## Tools and Setup
@@ -43,7 +43,7 @@ Ruff is used for linting and formatting the code. Configuration is available in 
 
 The `Makefile` provides a set of commands to streamline project setup and maintenance. Key commands include:
 
-- `make install`: Initialize the project, install dependencies, and set up pre-commit hooks.
+- `make init`: Initialize the project, install dev dependencies, and set up pre-commit hooks.
 - `make format`: Format the code using Ruff.
 - `make lint`: Lint the code using Ruff and MyPy.
 - `make security`: Run security checks using Bandit.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple cookiecutter template for general python projects, including:
 - test coverage with Codecov
 - linting \& formatting with ruff
 - security checks with bandit
-- dependency management with Poetry
+- dependency management with uv
 - pre-commit hooks with ruff and mypy
 - Makefile for automating common tasks
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,5 @@
   "project_name": "python-project",
   "package_name": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
   "project_slug": "{{ cookiecutter.package_name.replace('-', '_') }}",
-  "project_short_description": "Python project contains all the boilerplate you need to create a Python package.",
-  "_copy_without_render": [".github/workflows/build.yml"]
+  "project_short_description": "Python project contains all the boilerplate you need to create a Python package."
 }

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -52,6 +52,8 @@ jobs:
       # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
         uses: actions/setup-python@v5
         with:
-          python-version: "{% raw %}${{ matrix.python-version }}{% endraw %}"
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,12 +28,12 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: "{% raw %}${{ env.CODECOV_TOKEN != '' }}{% endraw %}"
+        if: {% raw %}${{ env.CODECOV_TOKEN != '' }}{% endraw %}
         env:
-          CODECOV_TOKEN: "{% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}"
+          CODECOV_TOKEN: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
         with:
-          token: "{% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}"
-          slug: "{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}"
+          token: {% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}
+          slug: {{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
 
   bump-version:
     needs: tox
@@ -49,8 +49,8 @@ jobs:
       # publishing to PyPI. Set PERSONAL_ACCESS_TOKEN secret and use the
       # following line instead of the one below it:
       #
-      # PERSONAL_ACCESS_TOKEN: "{% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
-      PERSONAL_ACCESS_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
+      # PERSONAL_ACCESS_TOKEN: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
+      PERSONAL_ACCESS_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -59,16 +59,16 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
+          token: {% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}
           fetch-depth: 0
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
+          github_token: {% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: "body.md"
-          tag_name: "{% raw %}${{ env.REVISION }}{% endraw %}"
-          token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
+          tag_name: {% raw %}${{ env.REVISION }}{% endraw %}
+          token: {% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Test with tox
         run: tox
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: ${{ env.CODECOV_TOKEN != '' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          slug: {{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
 
   bump-version:
     needs: tox

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -36,27 +36,34 @@ jobs:
     needs: tox
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     env:
-      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      # !! IMPORTANT !!
+      # Here PERSONAL_ACCESS_TOKEN is set to GITHUB_TOKEN, this is usually fine,
+      # but when you use the repository's GITHUB_TOKEN to perform tasks, events
+      # triggered by the GITHUB_TOKEN will not create a new workflow run. This
+      # prevents you from accidentally creating recursive workflow runs. You
+      # will want to configure a GitHub Actions secret with a Personal Access
+      # Token if you want GitHub Actions CI checks to run on releases, such as
+      # publishing to PyPI. Set PERSONAL_ACCESS_TOKEN secret and use the
+      # following line instead of the one below it:
+      #
+      # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        if: ${{ env.PERSONAL_ACCESS_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          token: "${{ env.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
       - name: Create bump and changelog
-        if: ${{ env.PERSONAL_ACCESS_TOKEN != '' }}
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ env.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
-        if: ${{ env.PERSONAL_ACCESS_TOKEN != '' }}
         uses: softprops/action-gh-release@v2
         with:
           body_path: "body.md"
           tag_name: ${{ env.REVISION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ env.PERSONAL_ACCESS_TOKEN }}

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python {% raw %}${{ matrix.python-version }}{% endraw %}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "{% raw %}${{ matrix.python-version }}{% endraw %}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -28,12 +28,12 @@ jobs:
         run: tox
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: "{% raw %}${{ env.CODECOV_TOKEN != '' }}{% endraw %}"
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: "{% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}"
         with:
-          token: ${{ env.CODECOV_TOKEN }}
-          slug: {{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}
+          token: "{% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}"
+          slug: "{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}"
 
   bump-version:
     needs: tox
@@ -49,8 +49,8 @@ jobs:
       # publishing to PyPI. Set PERSONAL_ACCESS_TOKEN secret and use the
       # following line instead of the one below it:
       #
-      # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-      PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # PERSONAL_ACCESS_TOKEN: "{% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
+      PERSONAL_ACCESS_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -59,16 +59,16 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          token: "${{ env.PERSONAL_ACCESS_TOKEN }}"
+          token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
           fetch-depth: 0
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ env.PERSONAL_ACCESS_TOKEN }}
+          github_token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: "body.md"
-          tag_name: ${{ env.REVISION }}
-          token: ${{ env.PERSONAL_ACCESS_TOKEN }}
+          tag_name: "{% raw %}${{ env.REVISION }}{% endraw %}"
+          token: "{% raw %}${{ env.PERSONAL_ACCESS_TOKEN }}{% endraw %}"

--- a/{{cookiecutter.package_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -13,24 +13,28 @@ repos:
         entry: make requirements
         language: system
         pass_filenames: false
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: format
         name: format
         entry: make format
         language: system
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: lint
         name: lint
         entry: make lint
         language: system
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: security
         name: security
         entry: make security
         language: system
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: test
@@ -38,3 +42,4 @@ repos:
         entry: make test
         language: system
         pass_filenames: false
+        stages: [pre-commit]

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 fail_fast: true
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.4.1
     hooks:
       - id: commitizen
-      - id: commitizen-branch
-        stages: [pre-push]
+        stages: [commit-msg]
   - repo: local
     hooks:
       - id: requirements

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -9,6 +9,13 @@ repos:
         stages: [push]
   - repo: local
     hooks:
+      - id: requirements
+        name: requirements
+        entry: make requirements
+        language: system
+        pass_filenames: false
+  - repo: local
+    hooks:
       - id: format
         name: format
         entry: make format
@@ -33,24 +40,6 @@ repos:
       - id: test
         name: test
         entry: make test
-        language: system
-        pass_filenames: false
-        stages: [pre-commit]
-  - repo: local
-    hooks:
-      - id: poetry-export
-        name: requirements
-        entry: poetry export
-        args:
-          [
-            "-f",
-            "requirements.txt",
-            "-o",
-            "requirements.txt",
-            "--with",
-            "dev",
-            "--without-hashes",
-          ]
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -1,12 +1,11 @@
 fail_fast: true
-default_install_hook_types: [pre-commit, commit-msg, pre-push]
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.42.1
     hooks:
       - id: commitizen
       - id: commitizen-branch
-        stages: [push]
+        stages: [pre-push]
   - repo: local
     hooks:
       - id: requirements
@@ -20,21 +19,18 @@ repos:
         name: format
         entry: make format
         language: system
-        stages: [pre-commit]
   - repo: local
     hooks:
       - id: lint
         name: lint
         entry: make lint
         language: system
-        stages: [pre-commit]
   - repo: local
     hooks:
       - id: security
         name: security
         entry: make security
         language: system
-        stages: [pre-commit]
   - repo: local
     hooks:
       - id: test
@@ -42,4 +38,3 @@ repos:
         entry: make test
         language: system
         pass_filenames: false
-        stages: [pre-commit]

--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: true
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.42.1
+    rev: v4.4.1
     hooks:
       - id: commitizen
       - id: commitizen-branch

--- a/{{cookiecutter.package_name}}/Makefile
+++ b/{{cookiecutter.package_name}}/Makefile
@@ -27,4 +27,5 @@ lint:
 
 security:
 	$(EXECUTER) bandit -r $(PROJECT_NAME)/
+	$(EXECUTER) pip-audit
 

--- a/{{cookiecutter.package_name}}/Makefile
+++ b/{{cookiecutter.package_name}}/Makefile
@@ -1,11 +1,11 @@
 PROJECT_NAME:={{cookiecutter.project_slug}}
-EXECUTER:=poetry run
+EXECUTER:=uv run
 
 all: format lint security test requirements
 
 install:
 	git init
-	$(EXECUTER) poetry install
+	$(EXECUTER) uv sync
 	$(EXECUTER) pre-commit install
 
 clean:
@@ -13,7 +13,7 @@ clean:
 	$(EXECUTER) ruff clean
 
 requirements:
-	poetry export -f requirements.txt -o requirements.txt --with dev --without-hashes
+	uv export --no-hashes --format requirements-txt > requirements.txt
 
 test:
 	$(EXECUTER) pytest --cov-report term-missing --cov-report html --cov $(PROJECT_NAME)/

--- a/{{cookiecutter.package_name}}/Makefile
+++ b/{{cookiecutter.package_name}}/Makefile
@@ -3,7 +3,7 @@ EXECUTER:=uv run
 
 all: format lint security test requirements
 
-install:
+init:
 	git init
 	$(EXECUTER) uv sync
 	$(EXECUTER) pre-commit install

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -1,7 +1,7 @@
 # {{ cookiecutter.package_name.title().replace('-', ' ').replace('_', ' ') }}
 
 [![Build](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/build.yml/badge.svg)](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/graph/badge.svg?token=5QJRTQZ9B0)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }})
+[![codecov](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/graph/badge.svg?token=XXX)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }})
 
 You can initialize the project with `git`, generate virtual environment and install dependencies with `uv` by running:
 

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -3,7 +3,7 @@
 [![Build](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/build.yml/badge.svg)](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }}/graph/badge.svg?token=5QJRTQZ9B0)](https://codecov.io/gh/{{ cookiecutter.github_username }}/{{ cookiecutter.package_name }})
 
-You can initialize the project with `git`, generate virtual environment and install dependencies with `Poetry` by running:
+You can initialize the project with `git`, generate virtual environment and install dependencies with `uv` by running:
 
 ```sh
 make install

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -6,5 +6,5 @@
 You can initialize the project with `git`, generate virtual environment and install dependencies with `uv` by running:
 
 ```sh
-make install
+make init
 ```

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -5,11 +5,12 @@ description = "{{ cookiecutter.project_short_description }}"
 authors = [
     { name = "{{ cookiecutter.full_name }}", email = "{{ cookiecutter.email }}" },
 ]
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 readme = "README.md"
 

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -68,8 +68,9 @@ disallow_untyped_defs = true
 name = "cz_conventional_commits"
 tag_format = "$version"
 version = "0.1.0"
+version_provider = "uv"
 version_files = [
-    "pyproject.toml:^version",
+    "pyproject.toml:version",
     "{{ cookiecutter.project_slug }}/__init__.py:__version__",
 ]
 major_version_zero = true

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -1,21 +1,38 @@
-[tool.poetry]
+[project]
 name = "{{ cookiecutter.package_name }}"
 version = "0.1.0"
 description = "{{ cookiecutter.project_short_description }}"
-authors = ["{{ cookiecutter.full_name }} <{{ cookiecutter.email }}>"]
+authors = [
+    { name = "{{ cookiecutter.full_name }}", email = "{{ cookiecutter.email }}" },
+]
+requires-python = ">=3.10,<3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+]
+readme = "README.md"
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.12"
+dependencies = []
 
-[tool.poetry.group.dev.dependencies]
-ruff = "^0.6.9"
-mypy = "^1.11.2"
-pre-commit = "^4.0.0"
-tox = "^4.21.2"
-commitizen = "^3.29.1"
-bandit = "^1.7.10"
-pytest = "^8.3.3"
-pytest-cov = "^5.0.0"
+[dependency-groups]
+dev = [
+    "bandit>=1.8.3",
+    "commitizen>=4.4.1",
+    "ipykernel>=6.29.5",
+    "ipython>=8.34.0",
+    "ipywidgets>=8.1.5",
+    "jupyter>=1.1.1",
+    "mypy>=1.15.0",
+    "pep8-naming>=0.14.1",
+    "pip-audit>=2.8.0",
+    "pre-commit>=4.2.0",
+    "pytest-cov>=6.0.0",
+    "pytest>=8.3.5",
+    "pyupgrade>=3.19.1",
+    "ruff>=0.11.0",
+    "tox>=4.24.2",
+]
 
 [tool.ruff]
 line-length = 100
@@ -56,7 +73,3 @@ version_files = [
 ]
 major_version_zero = true
 update_changelog_on_bump = true
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
+++ b/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
@@ -2,6 +2,7 @@ def test_import() -> None:
     """Test that the package can be imported without errors."""
     try:
         import {{ cookiecutter.project_slug }}
+
         print({{ cookiecutter.project_slug }}.__version__)
     except ImportError as e:
         raise AssertionError("Failed to import the package.") from e

--- a/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
+++ b/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
@@ -1,6 +1,7 @@
-def test_import():
+def test_import() -> None:
     """Test that the package can be imported without errors."""
     try:
         import {{ cookiecutter.project_slug }}
+        print({{ cookiecutter.project_slug }}.__version__)
     except ImportError as e:
         raise AssertionError("Failed to import the package.") from e

--- a/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
+++ b/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
@@ -1,6 +1,6 @@
-from {{ cookiecutter.project_slug }} import __version__
-
-
-def test_version() -> None:
-    assert __version__ == "0.1.0"
-
+def test_import():
+    """Test that the package can be imported without errors."""
+    try:
+        import {{ cookiecutter.project_slug }}
+    except ImportError as e:
+        raise AssertionError("Failed to import the package.") from e

--- a/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
+++ b/{{cookiecutter.package_name}}/tests/test_{{ cookiecutter.project_slug }}.py
@@ -1,8 +1,6 @@
+import {{ cookiecutter.project_slug }}
+
+
 def test_import() -> None:
     """Test that the package can be imported without errors."""
-    try:
-        import {{ cookiecutter.project_slug }}
-
-        print({{ cookiecutter.project_slug }}.__version__)
-    except ImportError as e:
-        raise AssertionError("Failed to import the package.") from e
+    assert isinstance({{ cookiecutter.project_slug }}.__name__, str)

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox
 env_list =
-    lint,type,py{310,311}
+    lint,type,py{310,311,312}
 
 [testenv]
 description = run tests
@@ -33,6 +33,9 @@ basepython = python3.10
 
 [testenv:py311]
 basepython = python3.11
+
+[testenv:py312]
+basepython = python3.12
 description = Run tests and code coverage
 passenv = *
 deps =
@@ -57,3 +60,4 @@ commands =
 python =
     3.10: py310
     3.11: py311
+    3.11: py312

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -41,7 +41,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest --cov=./ --cov-append --cov-report=xml term-missing {posargs:tests}
+    pytest --cov=./ --cov-append --cov-report=xml
     codecov -e TOXENV
 
 [testenv:py312]

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-requires =
-    tox
-env_list =
-    lint,type,py{310,311,312}
+env_list = lint, type, py{310,311,312}
 
 [testenv]
 description = run tests
@@ -51,4 +48,4 @@ commands =
 python =
     3.10: py310
     3.11: py311
-    3.11: py312
+    3.12: py312, lint, type

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -44,17 +44,8 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest --cov=./ --cov-append --cov-report=xml
+    pytest --cov=./ --cov-append --cov-report=xml {poeargs:tests}
     codecov -e TOXENV
-
-[testenv:py312]
-description = Run linter, type check and code coverage
-passenv = *
-commands =
-    ruff format .
-    ruff check --fix .
-    mypy {{cookiecutter.project_slug}} tests
-    pytest --cov=./ --cov-append --cov-report=xml
 
 [gh-actions]
 python =

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -1,20 +1,50 @@
 [tox]
 requires =
-    tox>=4
+    tox
 env_list =
-    py{310,311}
+    lint,type,py{310,311}
 
 [testenv]
-description = run unit tests
+description = run tests
 deps =
-    pytest>=7
-    pytest-cov>=4
-    mypy>=1
-    ruff>=0.1
+    pytest
 commands =
     pytest {posargs:tests}
 
+[testenv:lint]
+description = format and lint
+skip_install = true
+deps =
+    ruff
+commands =
+    ruff format .
+    ruff check --fix .
+
+[testenv:type]
+description = run type check
+skip_install = true
+deps =
+    mypy
+commands =
+    mypy {{cookiecutter.project_slug}} tests
+
+[testenv:py310]
+basepython = python3.10
+
 [testenv:py311]
+basepython = python3.11
+description = Run tests and code coverage
+passenv = *
+deps =
+    codecov
+    mypy
+    pytest
+    pytest-cov
+commands =
+    pytest --cov=./ --cov-append --cov-report=xml term-missing {posargs:tests}
+    codecov -e TOXENV
+
+[testenv:py312]
 description = Run linter, type check and code coverage
 passenv = *
 commands =


### PR DESCRIPTION
Update the cookiecutter setup from `poetry` based management to `uv`.

Also, update old actions and modernize and modularize the tox configuration.

In addition to existing Python 3.10 and 3.11 support, add 3.12 support with main development based on 3.12. 